### PR TITLE
PAB-66: fix piped interactive installs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { selfUpgrade } from "./upgrade";
 import { detectOS } from "./utils";
 import { color } from "./ui";
 import { showCursor, clearScreen } from "./renderer";
+import { openTerminalInput } from "./terminal";
 
 const VERSION = process.env.DOT_VERSION || "dev";
 
@@ -96,19 +97,28 @@ export async function main(): Promise<void> {
   }
 
   const isTty = process.stdin.isTTY ?? false;
-  const options = { dryRun: args.dryRun, verbose: args.verbose, interactive: isTty && args.mode === "direct" };
 
   if (args.mode === "interactive") {
+    const terminalInput = isTty ? null : openTerminalInput();
     if (!isTty) {
-      process.stderr.write(`${color("[error]", "red")} Interactive mode requires a terminal. Use --install, --link, or --dry-run flags for non-interactive use.\n`);
-      process.exit(1);
+      if (!terminalInput) {
+        process.stderr.write(`${color("[error]", "red")} Interactive mode requires a terminal. Use --install, --link, or --dry-run flags for non-interactive use.\n`);
+        process.exit(1);
+      }
     }
-    const selected = await runInteractive(resolved);
+
+    let selected;
+    try {
+      selected = await runInteractive(resolved, terminalInput || process.stdin);
+    } finally {
+      terminalInput?.destroy();
+    }
     if (selected.length === 0) {
       process.exit(0);
     }
 
     const action = args.interactiveAction;
+    const options = { dryRun: args.dryRun, verbose: args.verbose, interactive: true };
 
     for (const item of selected) {
       if (item.unavailable) continue;
@@ -161,6 +171,7 @@ export async function main(): Promise<void> {
   }
 
   if (args.mode === "direct") {
+    const options = { dryRun: args.dryRun, verbose: args.verbose, interactive: isTty };
     const names = resolved.map((c: { name: string }) => c.name);
 
     if (args.list) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -14,6 +14,23 @@ export interface RunResult {
   manager?: string;
 }
 
+async function runNonInteractive(command: string): Promise<{ exitCode: number; stderr: Buffer }> {
+  const shellCommand = process.platform === "win32"
+    ? [process.env.ComSpec || "cmd.exe", "/d", "/s", "/c", command]
+    : [Bun.which("bash") || "/bin/sh", "-c", command];
+  const child = Bun.spawn(shellCommand, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stderr).arrayBuffer(),
+    new Response(child.stdout).arrayBuffer(),
+  ]);
+  return { exitCode, stderr: Buffer.from(stderr) };
+}
+
 export async function installComponent(
   name: string,
   command: string | null,
@@ -42,7 +59,7 @@ export async function installComponent(
     if (options.interactive) {
       result = await Bun.$`${{ raw: command }}`.nothrow().quiet();
     } else {
-      result = await Bun.$`${{ raw: command }} < /dev/null`.nothrow().quiet();
+      result = await runNonInteractive(command);
     }
     if (result.exitCode !== 0) {
       if (options.verbose) {
@@ -92,7 +109,7 @@ export async function uninstallComponent(
     if (options.interactive) {
       result = await Bun.$`${{ raw: command }}`.nothrow().quiet();
     } else {
-      result = await Bun.$`${{ raw: command }} < /dev/null`.nothrow().quiet();
+      result = await runNonInteractive(command);
     }
     if (result.exitCode !== 0) {
       return { ...base, failed: true };

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -39,7 +39,10 @@ export function buildChecklist(components: ResolvedComponent[]): CheckboxItem[] 
   return items;
 }
 
-export async function runInteractive(components: ResolvedComponent[]): Promise<CheckboxItem[]> {
+export async function runInteractive(
+  components: ResolvedComponent[],
+  stdin: NodeJS.ReadStream = process.stdin
+): Promise<CheckboxItem[]> {
   const items = buildChecklist(components);
 
   const response = await prompts({
@@ -66,6 +69,7 @@ export async function runInteractive(components: ResolvedComponent[]): Promise<C
     }),
     hint: "✓=done  ⚠=no install method  (type to filter, space to select, enter to confirm)",
     instructions: false,
+    stdin,
     optionsPerPage: process.stdout.rows ? process.stdout.rows - 10 : 30,
     suggest: (input: string, choices: any[]) =>
       Promise.resolve(

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,0 +1,17 @@
+import { closeSync, openSync } from "node:fs";
+import { ReadStream } from "node:tty";
+
+export function openTerminalInput(terminalPath = "/dev/tty"): ReadStream | null {
+  if (process.platform === "win32") {
+    return null;
+  }
+
+  let terminalFd: number | null = null;
+  try {
+    terminalFd = openSync(terminalPath, "r");
+    return new ReadStream(terminalFd);
+  } catch {
+    if (terminalFd !== null) closeSync(terminalFd);
+    return null;
+  }
+}

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -1,5 +1,18 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { installComponent, uninstallComponent } from "../src/installer";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "dot-installer-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
 
 describe("installComponent", () => {
   test("returns success for echo command", async () => {
@@ -33,6 +46,18 @@ describe("installComponent", () => {
   test("null command returns failure", async () => {
     const result = await installComponent("custom", null as any, { dryRun: false, verbose: false, interactive: false });
     expect(result.failed).toBe(true);
+  });
+
+  test("non-interactive commands preserve pipeline input", async () => {
+    const marker = join(tmp, "mise-installed");
+    const result = await installComponent(
+      "mise",
+      `printf 'touch ${marker}' | sh`,
+      { dryRun: false, verbose: false, interactive: false }
+    );
+
+    expect(result.success).toBe(true);
+    expect(existsSync(marker)).toBe(true);
   });
 });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -2,9 +2,11 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { tmpdir } from "node:os";
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readlinkSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import prompts from "prompts";
 import { parseConfig, resolveComponents } from "../src/config";
 import { resolveComponentNames } from "../src/fuzzy";
 import { createLinks } from "../src/linker";
+import { main } from "../src/index";
 
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), "dot-integration-"));
@@ -59,6 +61,37 @@ postinstall = "echo 'git configured'"
     expect(gitLinks[0].success).toBe(true);
     expect(existsSync(join(homeDir, ".gitconfig"))).toBe(true);
     expect(existsSync(join(homeDir, ".config", "git", "config"))).toBe(true);
+  });
+
+  test("interactive installs preserve pipeline input", async () => {
+    const marker = join(repoDir, "mise-installed");
+    writeFileSync(join(repoDir, "dot.toml"), `
+[mise]
+install.any = "printf 'touch ${marker}' | sh"
+`);
+
+    const originalArgv = process.argv;
+    const originalCwd = process.cwd();
+    const originalIsTty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+
+    try {
+      process.argv = ["dot"];
+      process.chdir(repoDir);
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+      prompts.inject([["mise"]]);
+
+      await main();
+
+      expect(existsSync(marker)).toBe(true);
+    } finally {
+      process.argv = originalArgv;
+      process.chdir(originalCwd);
+      if (originalIsTty) {
+        Object.defineProperty(process.stdin, "isTTY", originalIsTty);
+      } else {
+        delete (process.stdin as any).isTTY;
+      }
+    }
   });
 
   test("dry run does not create links", async () => {

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { openTerminalInput } from "../src/terminal";
+
+describe("openTerminalInput", () => {
+  test("returns null when no terminal can be opened", async () => {
+    const result = openTerminalInput("/definitely/missing/dot-terminal");
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Title:** Fix piped interactive installs

This pull request fixes a bug where running `dot` in interactive mode with piped input (e.g., `echo "..." | dot`) would fail because the standard input was not a terminal. The changes ensure interactive prompts are still displayed and read from the real terminal even when stdin is redirected or piped. Additionally, non-interactive install commands are now executed with their standard input explicitly ignored, preventing them from accidentally consuming the parent’s piped data.

Major changes include:
- Added a `openTerminalInput` utility that opens `/dev/tty` to provide a terminal-backed input stream when `process.stdin` is not a TTY.
- Updated the interactive mode to fall back to the terminal stream if stdin is not a TTY, and to use that stream for the `prompts` checklist.
- Refactored command execution in `installComponent` and `uninstallComponent` to use `Bun.spawn` with `stdin: "ignore"` instead of appending `< /dev/null` to shell commands, avoiding unintended side effects with piped input.
- Added new tests covering both interactive and non-interactive scenarios to validate the fix.

This ensures `dot` behaves correctly in complex shell pipelines, whether running an interactive setup or executing automated installs.
<!-- kody-pr-summary:end -->